### PR TITLE
Add Java Modules via Java Modularity Plugin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,6 +23,8 @@ micronaut {
 dependencies {
     annotationProcessor "io.micronaut:micronaut-inject-java:${micronautVersion}"
     implementation "io.micronaut:micronaut-inject:${micronautVersion}"
+
+    testImplementation("org.junit.jupiter:junit-jupiter-engine:5.7.2")
 }
 
 application {
@@ -33,6 +35,13 @@ application {
 java {
     sourceCompatibility = JavaVersion.toVersion("11")
     targetCompatibility = JavaVersion.toVersion("11")
+}
+
+test {
+    useJUnitPlatform()
+    moduleOptions {
+        runOnClasspath = true
+    }
 }
 
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id("com.github.johnrengelman.shadow") version "7.0.0"
     id("io.micronaut.application") version "2.0.3"
+    id 'org.javamodularity.moduleplugin' version '1.8.7'
 }
 
 version = "0.1"
@@ -20,19 +21,15 @@ micronaut {
 }
 
 dependencies {
-    annotationProcessor("io.micronaut:micronaut-http-validation")
-    implementation("io.micronaut:micronaut-http-client")
-    implementation("io.micronaut:micronaut-runtime")
-    implementation("javax.annotation:javax.annotation-api")
-    runtimeOnly("ch.qos.logback:logback-classic")
-    implementation("io.micronaut:micronaut-validation")
-
+    annotationProcessor "io.micronaut:micronaut-inject-java:${micronautVersion}"
+    implementation "io.micronaut:micronaut-inject:${micronautVersion}"
 }
-
 
 application {
+    mainModule = 'app'
     mainClass.set("app.MinimalApp")
 }
+
 java {
     sourceCompatibility = JavaVersion.toVersion("11")
     targetCompatibility = JavaVersion.toVersion("11")

--- a/app/gradle.properties
+++ b/app/gradle.properties
@@ -1,1 +1,1 @@
-micronautVersion=3.0.0-RC1
+micronautVersion=3.0.0

--- a/app/gradle.properties
+++ b/app/gradle.properties
@@ -1,1 +1,1 @@
-micronautVersion=3.0.0
+micronautVersion=3.1.0

--- a/app/src/main/java/module-info.java
+++ b/app/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module app {
+    requires static jakarta.inject;
+    requires io.micronaut.inject;
+    exports app;
+}


### PR DESCRIPTION
Merge this pull-request and you'll ba able to reproduce the problem.

To reproduce, you must use:

`./gradlew run`

The problem only occurs at runtime. I had trouble getting the existing test framework to run once I added module support. 

Note that if you change `@Factory` to `@Singleton` it will run correctly.
